### PR TITLE
V1.1.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: 'To cite package "GeoLocatoR" in publications use:'
 type: software
 license: GPL-3.0-or-later
 title: 'GeoLocatoR: R package for GeoLocator Data Package'
-version: 1.0.2
+version: 1.1.0
 identifiers:
 - type: url
   value: https://geopressure.org/GeoLocatoR/
@@ -124,7 +124,7 @@ references:
     affiliation: Research Institute for Nature and Forest (INBO)
   year: '2026'
   doi: 10.32614/CRAN.package.frictionless
-  version: < 1.3.0
+  version: '>= 1.3.0'
 - type: software
   title: GeoPressureR
   abstract: 'GeoPressureR: Global Positioning by Atmospheric Pressure'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GeoLocatoR
 Title: R package for GeoLocator Data Package
-Version: 1.0.2
+Version: 1.1.0
 Authors@R: 
     c(
       person("Raphaël", "Nussbaumer", , "rafnuss@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-8185-1020")),
@@ -17,7 +17,7 @@ Imports:
     cli,
     desc,
     dplyr,
-    frictionless (< 1.3.0),
+    frictionless (>= 1.3.0),
     GeoPressureR (>= 3.5.4),
     glue,
     ggplot2,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,206 @@
+# GeoLocatoR 1.1.0
+
+- Added support for frictionless 1.3.0 and migrated to its `resource_names()`
+  API. GeoLocator-DP profile-version warnings are suppressed while the package
+  remains on Data Package v1. Compatibility with frictionless 2.0.0 will be
+  addressed separately.
+- Simplified internal resource updates by using frictionless's add-or-replace
+  behaviour.
+
+# GeoLocatoR 1.0.2
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/ae8532f...cbc8819) · [PR #33](https://github.com/GeoPressure/GeoLocatoR/pull/33)
+
+- Improved `read_gldp()` diagnostics for unreadable resources and added support
+  for passing a package directory.
+- Improved Darwin Core export by using most-likely paths for exported locations,
+  rounding elevations, and completing occurrence and event fields.
+- `read_soi()` now fails early when duplicate `GDL_ID` values are encountered.
+- Resolved package-check notes and tidyselect deprecation warnings.
+
+# GeoLocatoR 1.0.1
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/fcf7bb4...ae8532f) · [PR #31](https://github.com/GeoPressure/GeoLocatoR/pull/31)
+
+- Added `status_geopressuretemplate()` to inspect GeoPressureTemplate projects.
+- `read_geopressuretemplate()` now retains `ring_number` and `tag_comments`
+  from `config.yml`.
+- Improved GeoPressureTemplate tag creation, including manufacturer defaults and
+  movement-graph handling.
+- Added experimental lifecycle labels and require GeoPressureR 3.5.4 or later.
+- Made cloning GeoPressureTemplate repositories more reliable by quoting clone
+  arguments and reporting clone errors.
+
+# GeoLocatoR 1.0.0
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/v0.5...v1.0) · [PR #29](https://github.com/GeoPressure/GeoLocatoR/pull/29)
+
+- Released the first stable 1.0 version of GeoLocatoR and moved project URLs to
+  the GeoPressure organisation and domain.
+- Updated GeoLocator Data Package schema URLs to the GeoPressure location.
+- Added `select_gldp()` and helpers to remove measurements from packages.
+- Refined GLDP coherence checks and added clearer validation warnings.
+- Improved SOI import helpers, package merging, schema handling, and resource
+  parsing diagnostics.
+- Bundled local GeoLocator Data Package schemas for reproducible validation.
+- Reworked `merge_gldp()` to accept a list of packages and normalise parameters
+  before merging.
+- Added `write_gldp()` and `update_gldp_order_resources()`.
+- Added `normalize_gldp_params()` and improved resource-schema upgrades.
+- Removed deprecated path, stap, and edge fields; renamed `pitch` to
+  `mean_acceleration_z`.
+
+## Breaking changes
+
+- Renamed `add_gldp_geopressuretemplate()` to `read_geopressuretemplate()` and
+  `create_gldp_geopressuretemplate()` to `create_geopressuretemplate()`.
+- Renamed `add_gldp_soi()` to `read_soi()` and `read_gdl()` to `read_soi_gld()`.
+- Renamed `zenodo_to_gldp()` to `read_zenodo()` and stopped accepting Zenodo
+  records directly in `read_gldp()`.
+- Renamed `config2tibble()` to `config_to_tibble()`, `version()` to
+  `gldp_version()`, and several raw-tag and contributor conversion helpers.
+- Replaced the former Zenodo export workflow and removed `gldp_to_zenodo()`.
+
+# GeoLocatoR 0.5.1
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/v0.5...af4141e) · [PR #24](https://github.com/GeoPressure/GeoLocatoR/pull/24)
+
+- Corrected GeoLocator Data Package validation and parameter-to-observation
+  conversion for the current schema.
+
+# GeoLocatoR 0.5.0
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/v0.4...v0.5) · [PR #21](https://github.com/GeoPressure/GeoLocatoR/pull/21)
+
+- Improved package metadata cleanup, particularly contributor values, paths,
+  licences, identifiers, and citations.
+- Strengthened validation with local references, `oneOf` support, and concept
+  DOI checks.
+- Improved tag merging and normalised enum values while importing Zenodo data.
+- Improved GeoPressureTemplate datetime handling and removed missing values from
+  measurements where appropriate.
+
+# GeoLocatoR 0.4.0
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/40ba0d3...v0.4) · [PR #20](https://github.com/GeoPressure/GeoLocatoR/pull/20)
+
+- Updated package metadata and citations for GeoLocator Data Package v0.4.
+- Added configuration parsing improvements and clearer errors for missing
+  package components.
+
+# GeoLocatoR 0.2.10
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/4fc8957...40ba0d3) · [PR #19](https://github.com/GeoPressure/GeoLocatoR/pull/19)
+
+- Refined licence selection while creating GeoPressureTemplate projects.
+- Corrected type extraction during import.
+
+# GeoLocatoR 0.2.9
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/90d7844...4fc8957) · [Export commit](https://github.com/GeoPressure/GeoLocatoR/commit/4fc8957)
+
+- Added `gldp_to_dwc()` and `gldp_to_eml()` to export packages as Darwin Core
+  and Ecological Metadata Language.
+- Improved GeoPressureTemplate project path handling and pkgdown export
+  documentation.
+
+# GeoLocatoR 0.2.8
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/1cf0871...90d7844) · [PR #17](https://github.com/GeoPressure/GeoLocatoR/pull/17)
+
+- Added `config_to_tibble()` for converting GeoPressureTemplate `config.yml`
+  files to tibbles.
+- Added `gldp_to_tag()` to convert package data to GeoPressureR tag objects.
+- Removed the `gert` dependency and improved Git clone handling.
+- Extended `read_gldp()` to support Zenodo inputs and made raw-tag processing
+  conditional on new tag data.
+- Replaced the lintr workflow with air and jarl checks.
+
+# GeoLocatoR 0.2.7
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/cb53780...1cf0871) · [PR #13](https://github.com/GeoPressure/GeoLocatoR/pull/13)
+
+- Improved package validation, taxonomy selection, GeoPressureTemplate imports,
+  and resource-overwrite prompts.
+- Added map and most-likely-path plotting methods.
+- Improved handling of missing sex values, tag reads, and pressure-path data.
+- Adopted the GPL licence.
+
+# GeoLocatoR 0.2.6
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/5a65726...cb53780) · [URL fix](https://github.com/GeoPressure/GeoLocatoR/commit/cb53780)
+
+- Corrected package URLs and taxonomic metadata handling.
+
+# GeoLocatoR 0.2.5
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/3b5e158...5a65726) · [PR #12](https://github.com/GeoPressure/GeoLocatoR/pull/12)
+
+- Renamed `params2*` conversion helpers to `params_to_*`.
+- Improved `create_gldp()` validation, resource type and format validation, and
+  package messages.
+- Updated documentation, citations, tests, and code formatting.
+
+# GeoLocatoR 0.2.4
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/dffe123...3b5e158) · [PR #11](https://github.com/GeoPressure/GeoLocatoR/pull/11)
+
+- Improved GeoPressureTemplate import, package creation, SOI import defaults,
+  and pressure-path compatibility.
+
+# GeoLocatoR 0.2.3
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/fc12fd7...dffe123) · [PR #9](https://github.com/GeoPressure/GeoLocatoR/pull/9)
+
+- Added `merge_gldp()` for combining GeoLocator Data Packages.
+- Improved metadata update helpers, licence display, and
+  `create_geopressuretemplate()` labels.
+
+# GeoLocatoR 0.2.2
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/d3a620c...fc12fd7) · [PR #7](https://github.com/GeoPressure/GeoLocatoR/pull/7)
+
+- Added clearer errors for missing GeoPressureTemplate files and missing tag or
+  parameter data.
+- Improved handling of paths containing spaces and duplicate measurements.
+
+# GeoLocatoR 0.2.1
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/92f4a6a...d3a620c) · [PR #6](https://github.com/GeoPressure/GeoLocatoR/pull/6)
+
+- Improved the GeoPressureTemplate writing workflow and package test coverage.
+
+# GeoLocatoR 0.2.0
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/74734e2...92f4a6a) · [PR #5](https://github.com/GeoPressure/GeoLocatoR/pull/5)
+
+- Added Zenodo import and metadata conversion helpers.
+- Added SOI import support for GDL files and database data.
+- Added package-resource validation, computed-property updates, and
+  bibliographic-citation updates.
+- Improved package printing, resource loading, and handling of empty resources,
+  twilights, and staps.
+
+# GeoLocatoR 0.1.1
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/c33d28e...74734e2) · [Pkgdown setup](https://github.com/GeoPressure/GeoLocatoR/commit/f965d9c)
+
+- Added pkgdown site configuration and removed the package vignette.
+- Improved raw-data GeoPressureTemplate imports and handling of missing package
+  descriptions.
+
+# GeoLocatoR 0.1.0
+
+[Full changelog](https://github.com/GeoPressure/GeoLocatoR/compare/5e426dd...c33d28e) · [Version commit](https://github.com/GeoPressure/GeoLocatoR/commit/aa2d84a)
+
+- Added plotting for `geolocatordp` objects and pressure-path resources.
+- Added GeoPressureTemplate project creation, including `config.yml` creation
+  and optional opening of the new RStudio project.
+- Added package coherence checks, schema-based metadata ordering, and resource
+  type casting.
+
+# GeoLocatoR 0.0.0.9000
+
+[Initial development history](https://github.com/GeoPressure/GeoLocatoR/commits/5e426dd)
+
+- Initial development release of GeoLocatoR.

--- a/R/accessors.R
+++ b/R/accessors.R
@@ -15,7 +15,7 @@
     resource_name = resource_name,
     data = value,
     cast_type = TRUE,
-    replace = resource_name %in% frictionless::resources(x)
+    replace = resource_name %in% frictionless::resource_names(x)
   )
 
   post(x)

--- a/R/accessors.R
+++ b/R/accessors.R
@@ -15,7 +15,7 @@
     resource_name = resource_name,
     data = value,
     cast_type = TRUE,
-    replace = resource_name %in% frictionless::resource_names(x)
+    replace = TRUE
   )
 
   post(x)

--- a/R/create_geopressuretemplate.R
+++ b/R/create_geopressuretemplate.R
@@ -72,7 +72,7 @@ create_geopressuretemplate <- function(path, pkg = NULL, open = interactive()) {
     unlink(clone_stderr)
     cli_abort(c(
       "x" = "Failed to clone {.url https://github.com/GeoPressure/GeoPressureTemplate/} into {.path {path}}.",
-      if (length(clone_error) > 0) setNames(clone_error, rep(">", length(clone_error)))
+      if (length(clone_error) > 0) stats::setNames(clone_error, rep(">", length(clone_error)))
     ))
   }
   unlink(clone_stderr)

--- a/R/gldp_to_dwc.R
+++ b/R/gldp_to_dwc.R
@@ -193,7 +193,7 @@ gldp_to_dwc <- function(pkg, directory) {
     minimumElevationInMeters = numeric(),
     maximumElevationInMeters = numeric()
   )
-  if ("pressurepaths" %in% frictionless::resources(pkg)) {
+  if ("pressurepaths" %in% frictionless::resource_names(pkg)) {
     pp <- pressurepaths(pkg)
     if ("altitude" %in% names(pp)) {
       # Pressurepaths can include decimal stap_id values during flights.

--- a/R/gldp_to_eml.R
+++ b/R/gldp_to_eml.R
@@ -213,11 +213,10 @@ gldp_to_eml <- function(pkg, directory) {
 
   # Spatial
   if (!is.null(spatial)) {
-    # Extract bounding box from polygon
-    coords <- spatial$coordinates
-    # coords is array(dim=c(1,5,2))
-    lons <- coords[1, , 1]
-    lats <- coords[1, , 2]
+    # Extract bounding box from the polygon's outer ring.
+    coords <- matrix(unlist(spatial$coordinates[[1]]), ncol = 2, byrow = TRUE)
+    lons <- coords[, 1]
+    lats <- coords[, 2]
 
     coverage$geographicCoverage <- list(
       geographicDescription = "Bounding box of all locations",

--- a/R/gldp_to_tag.R
+++ b/R/gldp_to_tag.R
@@ -121,7 +121,7 @@ gldp_to_tag <- function(pkg, tag_id = NULL) {
 #' @noRd
 gldp_to_tag_single <- function(pkg, tid) {
   # Get measurements for this tag
-  if ("measurements" %in% frictionless::resources(pkg)) {
+  if ("measurements" %in% frictionless::resource_names(pkg)) {
     meas <- measurements(pkg) |>
       dplyr::filter(.data$tag_id == tid)
   } else {
@@ -268,7 +268,7 @@ gldp_to_tag_single <- function(pkg, tid) {
   }
 
   # Add stap data if available
-  if ("staps" %in% frictionless::resources(pkg)) {
+  if ("staps" %in% frictionless::resource_names(pkg)) {
     stap_data <- staps(pkg) |>
       dplyr::filter(.data$tag_id == tid) |>
       dplyr::select(-"tag_id")
@@ -287,7 +287,7 @@ gldp_to_tag_single <- function(pkg, tid) {
   }
 
   # Add twilight data if available
-  if ("twilights" %in% frictionless::resources(pkg)) {
+  if ("twilights" %in% frictionless::resource_names(pkg)) {
     twilight_data <- twilights(pkg) |>
       dplyr::filter(.data$tag_id == tid) |>
       dplyr::select(-"tag_id")

--- a/R/merge_gldp.R
+++ b/R/merge_gldp.R
@@ -73,7 +73,7 @@ merge_gldp <- function(x, y = NULL, ...) {
   # Normalize input packages and cache their available resources.
   purrr::walk(pkgs, check_gldp)
   pkgs <- purrr::map(pkgs, update_gldp)
-  resources_by_pkg <- purrr::map(pkgs, frictionless::resources)
+  resources_by_pkg <- purrr::map(pkgs, frictionless::resource_names)
   resources <- unique(unlist(resources_by_pkg, use.names = FALSE))
 
   # Warn when several spec versions are present.

--- a/R/plot.geolocatordp.R
+++ b/R/plot.geolocatordp.R
@@ -25,9 +25,9 @@
 #' @export
 plot.geolocatordp <- function(x, type = NULL, ...) {
   if (is.null(type)) {
-    if ("measurements" %in% frictionless::resources(x)) {
+    if ("measurements" %in% frictionless::resource_names(x)) {
       type <- "coverage"
-    } else if ("observations" %in% frictionless::resources(x)) {
+    } else if ("observations" %in% frictionless::resource_names(x)) {
       type <- "ring"
     } else {
       cli_abort("No coverage data available in the GeoLocator Data Package.")

--- a/R/read_geopressuretemplate.R
+++ b/R/read_geopressuretemplate.R
@@ -58,7 +58,7 @@ read_geopressuretemplate <- function(
   }
 
   # pkg has already data
-  if (length(frictionless::resources(pkg)) > 0) {
+  if (length(frictionless::resource_names(pkg)) > 0) {
     cli_bullets(
       c(
         "!" = "The {.pkg pkg} has already resources
@@ -74,7 +74,7 @@ read_geopressuretemplate <- function(
     if (is.na(res) || !res) {
       return(pkg)
     }
-    for (r in frictionless::resources(pkg)) {
+    for (r in frictionless::resource_names(pkg)) {
       pkg <- frictionless::remove_resource(pkg, r)
     }
   }

--- a/R/read_gldp.R
+++ b/R/read_gldp.R
@@ -55,7 +55,14 @@ read_gldp <- function(x = "datapackage.json", force_read = TRUE, drop_measuremen
     }
   }
 
-  pkg <- frictionless::read_package(x)
+  pkg <- withCallingHandlers(
+    frictionless::read_package(x),
+    warning = function(w) {
+      if (inherits(w, "frictionless_warning_version_not_supported")) {
+        invokeRestart("muffleWarning")
+      }
+    }
+  )
   base_dir <- dirname(x)
 
   if (!grepl("geolocator-dp-profile\\.json$", pkg$`$schema`)) {

--- a/R/read_gldp.R
+++ b/R/read_gldp.R
@@ -16,6 +16,7 @@
 #'   the returned object is self-contained in memory. This means that each
 #' resource is read immediately with [frictionless::read_resource()], cast to
 #' the schema types, stored in `resource$data`, and its `path` field is removed.
+#'   The `measurements` resource is read last.
 #' @param drop_measurements `r lifecycle::badge("experimental")` If `TRUE`,
 #'   drops the `measurements` resource after reading `datapackage.json` and
 #'   before the optional `force_read` step loads resource data into memory. Use
@@ -88,7 +89,8 @@ read_gldp <- function(x = "datapackage.json", force_read = TRUE, drop_measuremen
   # Goal: return a self-contained package where `resources[[i]]$data` is available
   # and `path` is dropped, while still surfacing readr parsing issues with location.
   if (force_read) {
-    pkg$resources <- purrr::map(pkg$resources, \(r) {
+    read_order <- order(vapply(pkg[["resources"]], \(r) identical(r[["name"]], "measurements"), logical(1)))
+    pkg[["resources"]][read_order] <- purrr::map(pkg[["resources"]][read_order], \(r) {
       resource_name <- as.character(r$name %||% NA_character_)[1]
       resource_path <- as.character(r$path %||% NA_character_)[1]
       resource_location <- if (!is.na(resource_path) && nzchar(resource_path)) {

--- a/R/read_soi.R
+++ b/R/read_soi.R
@@ -119,7 +119,7 @@ read_soi <- function(
       pkg,
       "measurements",
       m,
-      replace = "measurements" %in% frictionless::resource_names(pkg)
+      replace = TRUE
     )
   }
 
@@ -255,7 +255,7 @@ read_soi <- function(
       pkg,
       "tags",
       t,
-      replace = "tags" %in% frictionless::resource_names(pkg)
+      replace = TRUE
     )
   }
 
@@ -348,7 +348,7 @@ read_soi <- function(
       pkg,
       "observations",
       o,
-      replace = "observations" %in% frictionless::resource_names(pkg)
+      replace = TRUE
     )
   }
 

--- a/R/read_soi.R
+++ b/R/read_soi.R
@@ -61,7 +61,7 @@ read_soi <- function(
   }
 
   # Do not add any data if same id already presents in measurements
-  if ("measurements" %in% frictionless::resources(pkg)) {
+  if ("measurements" %in% frictionless::resource_names(pkg)) {
     m <- measurements(pkg)
     gdl <- gdl |> filter(!(.data$GDL_ID %in% unique(m$tag_id)))
   } else {
@@ -119,12 +119,12 @@ read_soi <- function(
       pkg,
       "measurements",
       m,
-      replace = "measurements" %in% frictionless::resources(pkg)
+      replace = "measurements" %in% frictionless::resource_names(pkg)
     )
   }
 
   # Only add tags and observations data to the tag_id not yet present in tag
-  if ("tags" %in% frictionless::resources(pkg)) {
+  if ("tags" %in% frictionless::resource_names(pkg)) {
     t <- tags(pkg)
     gdl_to <- gdl |> filter(!(.data$GDL_ID %in% t$tag_id))
   } else {
@@ -255,11 +255,11 @@ read_soi <- function(
       pkg,
       "tags",
       t,
-      replace = "tags" %in% frictionless::resources(pkg)
+      replace = "tags" %in% frictionless::resource_names(pkg)
     )
   }
 
-  if ("observations" %in% frictionless::resources(pkg)) {
+  if ("observations" %in% frictionless::resource_names(pkg)) {
     o <- observations(pkg)
   } else {
     o <- NULL
@@ -348,7 +348,7 @@ read_soi <- function(
       pkg,
       "observations",
       o,
-      replace = "observations" %in% frictionless::resources(pkg)
+      replace = "observations" %in% frictionless::resource_names(pkg)
     )
   }
 

--- a/R/update_gldp.R
+++ b/R/update_gldp.R
@@ -75,7 +75,7 @@ update_gldp_order_resources <- function(pkg) {
 #' @export
 update_gldp_temporal <- function(pkg) {
   check_gldp(pkg)
-  resources <- frictionless::resources(pkg)
+  resources <- frictionless::resource_names(pkg)
 
   if (!"measurements" %in% resources) {
     pkg$temporal <- NULL
@@ -108,7 +108,7 @@ update_gldp_temporal <- function(pkg) {
 #' @export
 update_gldp_taxonomic <- function(pkg) {
   check_gldp(pkg)
-  resources <- frictionless::resources(pkg)
+  resources <- frictionless::resource_names(pkg)
 
   if (!"tags" %in% resources) {
     pkg$taxonomic <- NULL
@@ -149,7 +149,7 @@ update_gldp_taxonomic <- function(pkg) {
 #' @export
 update_gldp_number_tags <- function(pkg) {
   check_gldp(pkg)
-  resources <- frictionless::resources(pkg)
+  resources <- frictionless::resource_names(pkg)
 
   out <- list()
 

--- a/R/validate_gldp_meta.R
+++ b/R/validate_gldp_meta.R
@@ -77,7 +77,7 @@ validate_gldp_meta <- function(pkg) {
     "Lund University",
     "British Antarctic Survey"
   )
-  if ("tags" %in% frictionless::resources(pkg)) {
+  if ("tags" %in% frictionless::resource_names(pkg)) {
     t <- tags(pkg)
     manufacturers <- unique(t$manufacturer)
     invalid_manufacturers <- manufacturers[

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -68,7 +68,7 @@ reference:
 
 navbar:
   structure:
-    left: [ reference, geopressure-manual, geolocator-dp ]
+    left: [ reference, news, geopressure-manual, geolocator-dp ]
   components:
     geopressure-manual:
       text: User Guide

--- a/tests/testthat/test-accessors.R
+++ b/tests/testthat/test-accessors.R
@@ -19,7 +19,7 @@ test_that("observations getter and setter work correctly", {
   pkg <- pkg_shared
 
   skip_if_not(
-    "observations" %in% frictionless::resources(pkg),
+    "observations" %in% frictionless::resource_names(pkg),
     "Package has no observations resource"
   )
 
@@ -35,7 +35,7 @@ test_that("measurements getter and setter work correctly", {
   pkg <- pkg_shared
 
   skip_if_not(
-    "measurements" %in% frictionless::resources(pkg),
+    "measurements" %in% frictionless::resource_names(pkg),
     "Package has no measurements resource"
   )
 
@@ -51,7 +51,7 @@ test_that("staps getter and setter work correctly", {
   pkg <- pkg_shared
 
   skip_if_not(
-    "staps" %in% frictionless::resources(pkg),
+    "staps" %in% frictionless::resource_names(pkg),
     "Package has no staps resource"
   )
 
@@ -67,7 +67,7 @@ test_that("twilights getter and setter work correctly", {
   pkg <- pkg_shared
 
   skip_if_not(
-    "twilights" %in% frictionless::resources(pkg),
+    "twilights" %in% frictionless::resource_names(pkg),
     "Package has no twilights resource"
   )
 
@@ -83,7 +83,7 @@ test_that("paths getter and setter work correctly", {
   pkg <- pkg_shared
 
   skip_if_not(
-    "paths" %in% frictionless::resources(pkg),
+    "paths" %in% frictionless::resource_names(pkg),
     "Package has no paths resource"
   )
 
@@ -99,7 +99,7 @@ test_that("edges getter and setter work correctly", {
   pkg <- pkg_shared
 
   skip_if_not(
-    "edges" %in% frictionless::resources(pkg),
+    "edges" %in% frictionless::resource_names(pkg),
     "Package has no edges resource"
   )
 
@@ -115,7 +115,7 @@ test_that("pressurepaths getter and setter work correctly", {
   pkg <- pkg_shared
 
   skip_if_not(
-    "pressurepaths" %in% frictionless::resources(pkg),
+    "pressurepaths" %in% frictionless::resource_names(pkg),
     "Package has no pressurepaths resource"
   )
 

--- a/tests/testthat/test-gldp_to_tag.R
+++ b/tests/testthat/test-gldp_to_tag.R
@@ -153,8 +153,8 @@ test_that("gldp_to_tag extracts stap and twilight data correctly", {
   pkg <- pkg_shared
 
   # Check if package has staps and twilights resources
-  has_staps <- "staps" %in% frictionless::resources(pkg)
-  has_twilights <- "twilights" %in% frictionless::resources(pkg)
+  has_staps <- "staps" %in% frictionless::resource_names(pkg)
+  has_twilights <- "twilights" %in% frictionless::resource_names(pkg)
 
   # Get the first tag_id
   tag_ids <- unique(tags(pkg)$tag_id)

--- a/tests/testthat/test-read_gldp.R
+++ b/tests/testthat/test-read_gldp.R
@@ -130,7 +130,7 @@ test_that("read_gldp canonicalizes legacy schema owners", {
 
   writeLines("tag_id\nid-1", file.path(dirname(path), "tags.csv"))
 
-  pkg <- suppressWarnings(read_gldp(path, force_read = FALSE))
+  pkg <- expect_no_warning(read_gldp(path, force_read = FALSE))
 
   expect_equal(
     pkg$`$schema`,

--- a/tests/testthat/test-upgrade_gldp.R
+++ b/tests/testthat/test-upgrade_gldp.R
@@ -51,10 +51,10 @@ test_that("upgrade_gldp migrates v0.1 package fields to v0.6", {
           stringsAsFactors = FALSE
         )
       )
-    ),
-    directory = "."
+    )
   )
   class(pkg) <- c("geolocatordp", "datapackage", "list")
+  attr(pkg, "directory") <- "."
 
   upgraded <- suppressMessages(upgrade_gldp(pkg, to_version = "v0.6"))
 
@@ -102,10 +102,10 @@ test_that("step v0.4 -> v0.5 reconstructs missing edges$type from j", {
           stringsAsFactors = FALSE
         )
       )
-    ),
-    directory = "."
+    )
   )
   class(pkg) <- c("geolocatordp", "datapackage", "list")
+  attr(pkg, "directory") <- "."
 
   upgraded <- suppressMessages(upgrade_gldp(pkg, to_version = "v0.5"))
   edges_data <- purrr::detect(upgraded$resources, \(r) r$name == "edges")$data
@@ -143,10 +143,10 @@ test_that("step v0.5 -> v0.6 preserves pressurepaths extra schema fields", {
           stringsAsFactors = FALSE
         )
       )
-    ),
-    directory = "."
+    )
   )
   class(pkg) <- c("geolocatordp", "datapackage", "list")
+  attr(pkg, "directory") <- "."
 
   upgraded <- suppressMessages(upgrade_gldp(pkg, to_version = "v0.6"))
   pressurepaths_res <- upgraded$resources[[1]]
@@ -245,10 +245,10 @@ test_that("upgrade_gldp migrates v0.6 package to v1.0 schema refs", {
           stringsAsFactors = FALSE
         )
       )
-    ),
-    directory = "."
+    )
   )
   class(pkg) <- c("geolocatordp", "datapackage", "list")
+  attr(pkg, "directory") <- "."
 
   msgs <- testthat::capture_messages({
     upgraded <- upgrade_gldp(pkg, to_version = "v1.0")


### PR DESCRIPTION
New minor version to upgrade to frictionless v1.3.0 #23 :

- [Replaced deprecated `frictionless::resources()` calls with `resource_names()`.](https://github.com/GeoPressure/GeoLocatoR/commit/f56f55b)
- [Suppressed Frictionless’s expected custom GeoLocator-DP profile-version warning when reading packages.](https://github.com/GeoPressure/GeoLocatoR/commit/8ee81ef)(https://github.com/GeoPressure/GeoLocatoR/commit/8ee81ef)
- [Updated legacy upgrade fixtures to use Frictionless’s `directory` attribute, eliminating 1.3 deprecation warnings.](https://github.com/GeoPressure/GeoLocatoR/commit/3d93da4)
- [Simplified internal resource updates to use Frictionless’s new add-or-replace behaviour with `replace = TRUE`.](https://github.com/GeoPressure/GeoLocatoR/commit/1054804)
- [Updated affected tests for the Frictionless API and warning behaviour.](https://github.com/GeoPressure/GeoLocatoR/commit/5fe0ac0)(https://github.com/GeoPressure/GeoLocatoR/commit/5fe0ac0)

None-frictionless upgrade related:

- [Fixed EML export of spatial coverage by correctly converting GeoJSON polygon coordinates before calculating its bounding box.](https://github.com/GeoPressure/GeoLocatoR/commit/e336162)(https://github.com/GeoPressure/GeoLocatoR/commit/e336162)
- [Qualified `stats::setNames()` to resolve the package-check NOTE.](https://github.com/GeoPressure/GeoLocatoR/commit/8c26d31)
- [Added a full `NEWS.md` changelog and exposed it in the pkgdown navigation.](https://github.com/GeoPressure/GeoLocatoR/commit/51eb638)